### PR TITLE
Separate StorageService and NetworkService initialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ reqwest = "0.10"
 sled = "0.34"
 image = "0.23"
 infer = "0.3"
-# Experimental Rust-native IPFS Embed
+# IPFS
 ipfs-embed = { git = "https://github.com/ipfs-rust/ipfs-embed.git", rev = "a852c5f637dfb08a97d5a08a08cc86e81f5c9d96" }
 libipld = "0.8"
+# ipld-collections = "0.3.0"


### PR DESCRIPTION
Refactor StorageService and NetworkService initialization separately to more easily alter configuration from defaults, and have a reference that can be passed to other methods. These references are then passed to the ipfs_embed `Ipfs` initializer, rather than relying on defaults.