### PR TITLE
Temporarily override 1MB size limit with usize::MAX.

### DIFF
--- a/src/data/content.rs
+++ b/src/data/content.rs
@@ -37,4 +37,5 @@ pub enum ContentItem {
 #[derive(Clone, DagCbor, Debug, Eq, PartialEq)]
 pub struct ContentItemBlock {
     pub content: ContentItem,
+    pub size_bytes: Bytes, // Content size, not total block size
 }

--- a/src/data/ipfs_client.rs
+++ b/src/data/ipfs_client.rs
@@ -5,8 +5,8 @@ use ipfs_embed::db::StorageService;
 use ipfs_embed::net::{NetworkConfig, NetworkService};
 use ipfs_embed::Ipfs;
 use libipld::cbor::DagCborCodec;
-use libipld::multihash::{Code};
-use libipld::store::{StoreParams, Store};
+use libipld::multihash::Code;
+use libipld::store::{Store, StoreParams};
 use libipld::{Cid, IpldCodec};
 
 use async_std::sync::{Arc, Mutex};
@@ -27,7 +27,11 @@ impl StoreParams for MaxBlockSizeStoreParams {
 
 #[derive(Clone)]
 pub struct IpfsClient {
-    ipfs: Ipfs<MaxBlockSizeStoreParams, StorageService<MaxBlockSizeStoreParams>, NetworkService<MaxBlockSizeStoreParams>>,
+    ipfs: Ipfs<
+        MaxBlockSizeStoreParams,
+        StorageService<MaxBlockSizeStoreParams>,
+        NetworkService<MaxBlockSizeStoreParams>,
+    >,
     storage: Arc<StorageService<MaxBlockSizeStoreParams>>,
     network: Arc<NetworkService<MaxBlockSizeStoreParams>>,
 }

--- a/src/data/ipfs_client.rs
+++ b/src/data/ipfs_client.rs
@@ -20,7 +20,7 @@ pub type IpfsClientRef = Arc<Mutex<IpfsClient>>;
 struct MaxBlockSizeStoreParams;
 
 impl StoreParams for MaxBlockSizeStoreParams {
-    const MAX_BLOCK_SIZE: usize = usize::MAX;
+    const MAX_BLOCK_SIZE: usize = u32::MAX as usize - 1;
     type Codecs = IpldCodec;
     type Hashes = Code;
 }

--- a/src/data/ipfs_client.rs
+++ b/src/data/ipfs_client.rs
@@ -5,9 +5,9 @@ use ipfs_embed::db::StorageService;
 use ipfs_embed::net::{NetworkConfig, NetworkService};
 use ipfs_embed::Ipfs;
 use libipld::cbor::DagCborCodec;
-use libipld::multihash::Code;
-use libipld::store::{DefaultParams, Store};
-use libipld::Cid;
+use libipld::multihash::{Code};
+use libipld::store::{StoreParams, Store};
+use libipld::{Cid, IpldCodec};
 
 use async_std::sync::{Arc, Mutex};
 use directories_next::ProjectDirs;
@@ -16,11 +16,20 @@ use crate::data::content::ContentItemBlock;
 
 pub type IpfsClientRef = Arc<Mutex<IpfsClient>>;
 
+#[derive(Clone, Debug, Default)]
+struct MaxBlockSizeStoreParams;
+
+impl StoreParams for MaxBlockSizeStoreParams {
+    const MAX_BLOCK_SIZE: usize = usize::MAX;
+    type Codecs = IpldCodec;
+    type Hashes = Code;
+}
+
 #[derive(Clone)]
 pub struct IpfsClient {
-    ipfs: Ipfs<DefaultParams, StorageService<DefaultParams>, NetworkService<DefaultParams>>,
-    storage: Arc<StorageService<DefaultParams>>,
-    network: Arc<NetworkService<DefaultParams>>,
+    ipfs: Ipfs<MaxBlockSizeStoreParams, StorageService<MaxBlockSizeStoreParams>, NetworkService<MaxBlockSizeStoreParams>>,
+    storage: Arc<StorageService<MaxBlockSizeStoreParams>>,
+    network: Arc<NetworkService<MaxBlockSizeStoreParams>>,
 }
 
 impl IpfsClient {

--- a/src/data/ipfs_ops.rs
+++ b/src/data/ipfs_ops.rs
@@ -116,7 +116,8 @@ mod tests {
             data: &'static [u8],
             file_name: &'static str,
             expected: ContentItem,
-        };
+        }
+
         let tests = vec![
             Test {
                 name: "round-trip smallest possible gif",

--- a/src/data/ipfs_ops.rs
+++ b/src/data/ipfs_ops.rs
@@ -1,7 +1,7 @@
 use async_std::fs;
 use async_std::sync::Arc;
 use ipfs_embed::core::{Cid, Error, Result};
-use log::{info, error};
+use log::{error, info};
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::time::Instant;
@@ -43,7 +43,11 @@ pub async fn store_file(
         let ipfs_client = &ipfs_client.lock().await;
         let cid = ipfs_client.add(&block).await?;
 
-        info!("Stored {:.2?}MB in {:.2?}.", size_bytes as f32 / 1_048_576_f32, start.elapsed());
+        info!(
+            "Stored {:.2?}MB in {:.2?}.",
+            size_bytes as f32 / 1_048_576_f32,
+            start.elapsed()
+        );
 
         Ok(Some(cid))
     } else {
@@ -57,7 +61,11 @@ pub async fn store_file(
                 let ipfs_client = &ipfs_client.lock().await;
                 let cid = ipfs_client.add(&block).await?;
 
-                info!("Stored {:.2?}MB in {:.2?}.", size_bytes as f32 / 1_048_576_f32, start.elapsed());
+                info!(
+                    "Stored {:.2?}MB in {:.2?}.",
+                    size_bytes as f32 / 1_048_576_f32,
+                    start.elapsed()
+                );
 
                 Ok(Some(cid))
             }
@@ -82,7 +90,11 @@ pub async fn load_file(
     let cid = Cid::from_str(&cid_string).unwrap();
     let data = ipfs_client.get(&cid).await?;
 
-    info!("Loaded {:.2?}MB in {:.2?}.", data.size_bytes as f32 / 1_048_576_f32, start.elapsed());
+    info!(
+        "Loaded {:.2?}MB in {:.2?}.",
+        data.size_bytes as f32 / 1_048_576_f32,
+        start.elapsed()
+    );
 
     Ok(data.content)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use iced::{
 use iced_native::{window::Event::FileDropped, Event};
 
 use async_std::sync::{Arc, Mutex};
-use log::error;
+use log::{error, info};
 
 mod data;
 mod message;
@@ -27,6 +27,10 @@ use data::ipfs_client::{IpfsClient, IpfsClientRef};
 use data::ipfs_ops::{load_file, store_file};
 
 pub fn main() -> iced::Result {
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "fuzzr");
+    }
+
     pretty_env_logger::init();
 
     Fuzzr::run(Settings::default())
@@ -118,7 +122,7 @@ impl Application for Fuzzr {
                 match cid {
                     Ok(maybe_cid) => match maybe_cid {
                         Some(cid) => {
-                            println!("Content successfully added to IPFS! Cid: {}", cid);
+                            info!("Content successfully added to IPFS! Cid: {}", cid);
                         }
                         None => {
                             error!("No CID was returned when attempting to store content in IPFS.");


### PR DESCRIPTION
Resolves #55 (for now).

A better solution will arrive later. Also, adding a 17MB file is incredibly fast. I'll probably try with bigger soon enough.

Also, me being super curious about performance, I download this image and try adding it:
https://commons.wikimedia.org/wiki/File:The_Garden_of_Earthly_Delights_by_Bosch_High_Resolution.jpg

These are the results:

![Screenshot from 2021-01-06 10-47-03](https://user-images.githubusercontent.com/285690/103802985-2cb83a00-500d-11eb-89c3-23adb5c11eb1.png)

Basically, it adds and loads very quickly, but it's also too large to be displayed by what's needed to view it.

I did also try an enormous .txt file I had sitting around. That worked just fine:

![Screenshot from 2021-01-06 10-49-51](https://user-images.githubusercontent.com/285690/103803012-3641a200-500d-11eb-9750-4332d9fd2c4f.png)

Not terrible!