### PR TITLE
perf: basic criterion benchmarks for store and load of text

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -489,6 +489,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "771fe0050b883fcc3ea2359b1a96bcfbc090b7116eae7c3c512c7a083fdf23d3"
 
 [[package]]
+name = "bstr"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "473fc6b38233f9af7baa94fb5852dca389e3d95b8e21c8e3719301462c5d9faf"
+dependencies = [
+ "lazy_static",
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -564,6 +576,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9434b9a5aa1450faa3f9cb14ea0e8c53bb5d2b3c1bfd1ab4fc03e9f33fbfb0"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "cc"
 version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -616,6 +637,17 @@ dependencies = [
  "multibase 0.8.0",
  "multihash",
  "unsigned-varint",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "bitflags",
+ "textwrap",
+ "unicode-width",
 ]
 
 [[package]]
@@ -847,6 +879,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "criterion"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70daa7ceec6cf143990669a04c7df13391d55fb27bd4079d252fca774ba244d8"
+dependencies = [
+ "atty",
+ "cast",
+ "clap",
+ "criterion-plot",
+ "csv",
+ "itertools 0.9.0",
+ "lazy_static",
+ "num-traits",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_cbor",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022feadec601fba1649cfa83586381a4ad31c6bf3a9ab7d408118b05dd9889d"
+dependencies = [
+ "cast",
+ "itertools 0.9.0",
+]
+
+[[package]]
 name = "crossbeam-channel"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -916,6 +984,28 @@ checksum = "b584a330336237c1eecd3e94266efb216c56ed91225d634cb2991c5f3fd1aeab"
 dependencies = [
  "generic-array 0.14.4",
  "subtle 2.4.0",
+]
+
+[[package]]
+name = "csv"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d58633299b24b515ac72a3f869f8b91306a3cec616a602843a383acd6f9e97"
+dependencies = [
+ "bstr",
+ "csv-core",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "csv-core"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1500,6 +1590,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-std",
+ "criterion",
  "directories-next",
  "iced",
  "iced_futures",
@@ -1812,6 +1903,12 @@ dependencies = [
  "tracing",
  "tracing-futures",
 ]
+
+[[package]]
+name = "half"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d36fab90f82edc3c747f9d438e06cf0a491055896f2a279638bb5beed6c40177"
 
 [[package]]
 name = "hashbrown"
@@ -2248,6 +2345,15 @@ name = "itertools"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "284f18f85651fe11e8a991b2adb42cb078325c996ed026d994719efcfca1d54b"
 dependencies = [
  "either",
 ]
@@ -3260,6 +3366,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13bd41f508810a131401606d54ac32a467c97172d74ba7662562ebba5ad07fa0"
 
 [[package]]
+name = "oorandom"
+version = "11.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ab1bc2a289d34bd04a330323ac98a1b4bc82c9d9fcb1e66b63caa84da26b575"
+
+[[package]]
 name = "opaque-debug"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3480,6 +3592,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
 
 [[package]]
+name = "plotters"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d1685fbe7beba33de0330629da9d955ac75bd54f33d7b79f9a895590124f6bb"
+dependencies = [
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "png"
 version = "0.16.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3613,7 +3737,7 @@ checksum = "02b10678c913ecbd69350e8535c3aef91a8676c0773fc1d7b95cdd196d7f2f26"
 dependencies = [
  "bytes",
  "heck",
- "itertools",
+ "itertools 0.8.2",
  "log",
  "multimap",
  "petgraph",
@@ -3630,7 +3754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "537aa19b95acde10a12fec4301466386f757403de4cd4e5b4fa78fb5ecb18f72"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.8.2",
  "proc-macro2",
  "quote",
  "syn",
@@ -3816,6 +3940,15 @@ dependencies = [
  "memchr",
  "regex-syntax",
  "thread_local",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae1ded71d66a4a97f5e961fd0cb25a5f366a42a41570d16a763a69c092c26ae4"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -4025,6 +4158,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06c64263859d87aa2eb554587e2d23183398d617427327cf2b3d0ed8c69e4800"
 dependencies = [
  "serde_derive",
+]
+
+[[package]]
+name = "serde_cbor"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e18acfa2f90e8b735b2836ab8d538de304cbb6729a7360729ea5a895d15a622"
+dependencies = [
+ "half",
+ "serde",
 ]
 
 [[package]]
@@ -4359,6 +4502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4402,6 +4554,16 @@ dependencies = [
  "jpeg-decoder",
  "miniz_oxide 0.4.3",
  "weezl",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2ada8616fad06a2d0c455adc530de4ef57605a8120cc65da9653e0e9623ca74"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -4603,6 +4765,12 @@ name = "unicode-segmentation"
 version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,3 +49,8 @@ libipld = "0.8"
 
 [dev-dependencies]
 tempfile = "3.1"
+criterion = "0.3"
+
+[[bench]]
+name = "ipfs"
+harness = false

--- a/benches/ipfs.rs
+++ b/benches/ipfs.rs
@@ -1,0 +1,110 @@
+use fuzzr::data::{
+    content::ContentItem,
+    ipfs_client::{IpfsClient, IpfsClientRef},
+};
+use fuzzr::data::{
+    content::TextContent,
+    ipfs_ops::{load_file, store_file},
+};
+
+use async_std::{
+    sync::{Arc, Mutex},
+    task::block_on,
+};
+use criterion::{
+    criterion_group, criterion_main, AxisScale, Criterion, PlotConfiguration, Throughput,
+};
+use tempfile::tempdir;
+
+use std::{
+    error::Error,
+    fs::File,
+    io::Write,
+    path::{Path, PathBuf},
+};
+
+/// Helper to create file in a directory and return full path.
+fn write_file<P>(dir: P, data: &[u8], file_name: &str) -> Result<PathBuf, Box<dyn Error>>
+where
+    P: AsRef<Path>,
+{
+    let path = dir.as_ref().join(file_name);
+    let mut file = File::create(&path)?;
+    file.write_all(data)?;
+    Ok(path)
+}
+
+fn new_client() -> Result<IpfsClientRef, Box<dyn Error>> {
+    block_on(async {
+        Ok(Arc::new(Mutex::new(
+            IpfsClient::new()
+                .await
+                .map_err(|e| Arc::try_unwrap(e).unwrap())?,
+        )))
+    })
+}
+
+fn criterion_benchmark_ipfs_text(c: &mut Criterion) {
+    const KB: usize = 1024;
+    let dir = tempdir().unwrap();
+    let client_ref = new_client().unwrap();
+
+    {
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("load_text_throughput");
+        group.plot_config(plot_config);
+
+        for size in [KB, 16 * KB, 256 * KB, 1000 * KB].iter() {
+            let bees = vec![66; *size];
+            let file_name = format!("B_{}.txt", size);
+            let path = write_file(dir.path(), bees.as_slice(), &file_name).unwrap();
+
+            let client_ref_c = client_ref.clone();
+            let cid = block_on(store_file(path, client_ref_c))
+                .unwrap()
+                .unwrap()
+                .to_string();
+
+            let client_ref = client_ref.clone();
+            group.throughput(Throughput::Bytes(*size as u64));
+            group.bench_with_input(format!("{}_bytes", size), &cid, |b, cid| {
+                b.iter(|| {
+                    if let ContentItem::Text(TextContent { string }, _) =
+                        block_on(load_file(cid.clone(), client_ref.clone())).unwrap()
+                    {
+                        assert!(string.starts_with('B'));
+                        assert_eq!(string.len(), *size);
+                    }
+                })
+            });
+        }
+        group.finish();
+    }
+
+    {
+        let plot_config = PlotConfiguration::default().summary_scale(AxisScale::Logarithmic);
+        let mut group = c.benchmark_group("store_text_throughput");
+        group.plot_config(plot_config);
+
+        for size in [KB, 16 * KB, 256 * KB, 1000 * KB].iter() {
+            let tees = vec![84; *size];
+            let file_name = format!("T_{}.txt", size);
+            let path = write_file(dir.path(), tees.as_slice(), &file_name).unwrap();
+
+            group.throughput(Throughput::Bytes(*size as u64));
+            group.bench_with_input(format!("{}_bytes", size), &path, |b, path| {
+                b.iter(|| {
+                    let cid = block_on(store_file(path.clone(), client_ref.clone()))
+                        .unwrap()
+                        .unwrap()
+                        .to_string();
+                    assert!(!cid.is_empty());
+                })
+            });
+        }
+        group.finish();
+    }
+}
+
+criterion_group!(benches, criterion_benchmark_ipfs_text);
+criterion_main!(benches);

--- a/src/bin/fuzzr.rs
+++ b/src/bin/fuzzr.rs
@@ -6,26 +6,20 @@ use iced_native::{window::Event::FileDropped, Event};
 use async_std::sync::{Arc, Mutex};
 use log::{error, info};
 
-mod data;
-mod message;
-mod page;
-mod ui;
-
-use page::PageType;
-
-use page::dashboard::DashPage;
-use page::feed::FeedPage;
-use page::publish::PublishPage;
-use page::settings::SettingsPage;
-use page::site::SitePage;
-use page::view::ViewPage;
-
-use message::Message;
-use ui::style::Theme;
-use ui::toolbar::Toolbar;
-
-use data::ipfs_client::{IpfsClient, IpfsClientRef};
-use data::ipfs_ops::{load_file, store_file};
+use fuzzr::{
+    data::ipfs_client::{IpfsClient, IpfsClientRef},
+    data::ipfs_ops::{load_file, store_file},
+    message::Message,
+    page::dashboard::DashPage,
+    page::feed::FeedPage,
+    page::publish::PublishPage,
+    page::settings::SettingsPage,
+    page::site::SitePage,
+    page::view::ViewPage,
+    page::PageType,
+    ui::style::Theme,
+    ui::toolbar::Toolbar,
+};
 
 pub fn main() -> iced::Result {
     if std::env::var("RUST_LOG").is_err() {
@@ -59,7 +53,7 @@ pub struct Fuzzr {
 
 impl Application for Fuzzr {
     type Executor = iced::executor::Default;
-    type Message = message::Message;
+    type Message = fuzzr::message::Message;
     type Flags = ();
 
     fn new(_flags: ()) -> (Fuzzr, Command<Message>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,4 @@
+pub mod data;
+pub mod message;
+pub mod page;
+pub mod ui;


### PR DESCRIPTION
I had to move src/main.rs into src/bin/fuzzr.rs as benches
cannot import the lib of a binary.

Here is an example report:

```
Benchmarking load_text_throughput/1024_bytes
Benchmarking load_text_throughput/1024_bytes: Warming up for 3.0000 s
Benchmarking load_text_throughput/1024_bytes: Collecting 100 samples in estimated 5.0522 s (252k iterations)
Benchmarking load_text_throughput/1024_bytes: Analyzing
load_text_throughput/1024_bytes
                        time:   [19.818 us 20.226 us 20.698 us]
                        thrpt:  [47.181 MiB/s 48.282 MiB/s 49.277 MiB/s]
                 change:
                        time:   [-4.0016% -1.3089% +1.4003%] (p = 0.33 > 0.05)
                        thrpt:  [-1.3809% +1.3262% +4.1684%]
                        No change in performance detected.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
Benchmarking load_text_throughput/16384_bytes
Benchmarking load_text_throughput/16384_bytes: Warming up for 3.0000 s
Benchmarking load_text_throughput/16384_bytes: Collecting 100 samples in estimated 5.0427 s (237k iterations)
Benchmarking load_text_throughput/16384_bytes: Analyzing
load_text_throughput/16384_bytes
                        time:   [21.155 us 21.456 us 21.830 us]
                        thrpt:  [715.76 MiB/s 728.22 MiB/s 738.58 MiB/s]
                 change:
                        time:   [-1.4959% +0.2366% +1.8887%] (p = 0.78 > 0.05)
                        thrpt:  [-1.8537% -0.2360% +1.5186%]
                        No change in performance detected.
Found 14 outliers among 100 measurements (14.00%)
  14 (14.00%) high severe
Benchmarking load_text_throughput/262144_bytes
Benchmarking load_text_throughput/262144_bytes: Warming up for 3.0000 s
Benchmarking load_text_throughput/262144_bytes: Collecting 100 samples in estimated 5.2214 s (91k iterations)
Benchmarking load_text_throughput/262144_bytes: Analyzing
load_text_throughput/262144_bytes
                        time:   [56.666 us 57.265 us 58.031 us]
                        thrpt:  [4.2071 GiB/s 4.2633 GiB/s 4.3085 GiB/s]
                 change:
                        time:   [-1.7947% +0.5167% +3.1932%] (p = 0.71 > 0.05)
                        thrpt:  [-3.0944% -0.5141% +1.8275%]
                        No change in performance detected.
Found 11 outliers among 100 measurements (11.00%)
  2 (2.00%) high mild
  9 (9.00%) high severe
Benchmarking load_text_throughput/1024000_bytes
Benchmarking load_text_throughput/1024000_bytes: Warming up for 3.0000 s
Benchmarking load_text_throughput/1024000_bytes: Collecting 100 samples in estimated 5.1192 s (25k iterations)
Benchmarking load_text_throughput/1024000_bytes: Analyzing
load_text_throughput/1024000_bytes
                        time:   [188.78 us 191.93 us 195.37 us]
                        thrpt:  [4.8815 GiB/s 4.9689 GiB/s 5.0519 GiB/s]
                 change:
                        time:   [-2.9584% +0.4243% +4.3536%] (p = 0.82 > 0.05)
                        thrpt:  [-4.1720% -0.4225% +3.0486%]
                        No change in performance detected.
Found 7 outliers among 100 measurements (7.00%)
  4 (4.00%) high mild
  3 (3.00%) high severe

Benchmarking store_text_throughput/1024_bytes
Benchmarking store_text_throughput/1024_bytes: Warming up for 3.0000 s
Benchmarking store_text_throughput/1024_bytes: Collecting 100 samples in estimated 5.2461 s (66k iterations)
Benchmarking store_text_throughput/1024_bytes: Analyzing
store_text_throughput/1024_bytes
                        time:   [77.428 us 78.358 us 79.522 us]
                        thrpt:  [12.280 MiB/s 12.463 MiB/s 12.613 MiB/s]
                 change:
                        time:   [-3.7098% -1.7624% +0.2276%] (p = 0.08 > 0.05)
                        thrpt:  [-0.2271% +1.7941% +3.8528%]
                        No change in performance detected.
Found 13 outliers among 100 measurements (13.00%)
  1 (1.00%) low mild
  1 (1.00%) high mild
  11 (11.00%) high severe
Benchmarking store_text_throughput/16384_bytes
Benchmarking store_text_throughput/16384_bytes: Warming up for 3.0000 s
Benchmarking store_text_throughput/16384_bytes: Collecting 100 samples in estimated 5.4411 s (61k iterations)
Benchmarking store_text_throughput/16384_bytes: Analyzing
store_text_throughput/16384_bytes
                        time:   [92.245 us 94.675 us 97.175 us]
                        thrpt:  [160.79 MiB/s 165.04 MiB/s 169.39 MiB/s]
                 change:
                        time:   [+2.0510% +5.4291% +9.5546%] (p = 0.00 < 0.05)
                        thrpt:  [-8.7213% -5.1495% -2.0098%]
                        Performance has regressed.
Found 23 outliers among 100 measurements (23.00%)
  10 (10.00%) high mild
  13 (13.00%) high severe
Benchmarking store_text_throughput/262144_bytes
Benchmarking store_text_throughput/262144_bytes: Warming up for 3.0000 s
Benchmarking store_text_throughput/262144_bytes: Collecting 100 samples in estimated 5.4979 s (20k iterations)
Benchmarking store_text_throughput/262144_bytes: Analyzing
store_text_throughput/262144_bytes
                        time:   [274.98 us 281.16 us 288.82 us]
                        thrpt:  [865.58 MiB/s 889.17 MiB/s 909.15 MiB/s]
                 change:
                        time:   [+3.9246% +6.7403% +9.6361%] (p = 0.00 < 0.05)
                        thrpt:  [-8.7891% -6.3147% -3.7764%]
                        Performance has regressed.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
Benchmarking store_text_throughput/1024000_bytes
Benchmarking store_text_throughput/1024000_bytes: Warming up for 3.0000 s
Benchmarking store_text_throughput/1024000_bytes: Collecting 100 samples in estimated 8.9799 s (10k iterations)
Benchmarking store_text_throughput/1024000_bytes: Analyzing
store_text_throughput/1024000_bytes
                        time:   [831.94 us 853.01 us 877.59 us]
                        thrpt:  [1.0867 GiB/s 1.1180 GiB/s 1.1463 GiB/s]
                 change:
                        time:   [+2.4954% +6.3998% +10.654%] (p = 0.00 < 0.05)
                        thrpt:  [-9.6281% -6.0148% -2.4347%]
                        Performance has regressed.
Found 6 outliers among 100 measurements (6.00%)
  5 (5.00%) high mild
  1 (1.00%) high severe

```

I have yet to add image benchmarks;  I'm not sure how to generate a variety of sizes yet.

Signed-off-by: Chris Goller <goller@gmail.com>