### PR TITLE
Switch from Mutex to RwLock

### DIFF
--- a/benches/ipfs.rs
+++ b/benches/ipfs.rs
@@ -8,7 +8,7 @@ use fuzzr::data::{
 };
 
 use async_std::{
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
     task::block_on,
 };
 use criterion::{
@@ -36,7 +36,7 @@ where
 
 fn new_client() -> Result<IpfsClientRef, Box<dyn Error>> {
     block_on(async {
-        Ok(Arc::new(Mutex::new(
+        Ok(Arc::new(RwLock::new(
             IpfsClient::new()
                 .await
                 .map_err(|e| Arc::try_unwrap(e).unwrap())?,

--- a/src/bin/fuzzr.rs
+++ b/src/bin/fuzzr.rs
@@ -7,7 +7,7 @@ use iced_native::{
     Event,
 };
 
-use async_std::sync::{Arc, Mutex};
+use async_std::sync::{Arc, RwLock};
 use log::{error, info};
 use std::path::PathBuf;
 
@@ -30,10 +30,10 @@ use fuzzr::{
 
 async fn push_thumb_paths(
     paths: Vec<PathBuf>,
-    publish_thumbs_paths: Arc<Mutex<Vec<PathBuf>>>,
+    publish_thumbs_paths: Arc<RwLock<Vec<PathBuf>>>,
 ) -> usize {
     let len = paths.len();
-    publish_thumbs_paths.lock().await.extend(paths);
+    publish_thumbs_paths.write().await.extend(paths);
     len
 }
 
@@ -69,7 +69,7 @@ pub struct Fuzzr {
     pages: Pages, // All pages in the app
     toolbar: Toolbar,
     background_color: Color,
-    publish_thumbs_paths: Arc<Mutex<Vec<PathBuf>>>,
+    publish_thumbs_paths: Arc<RwLock<Vec<PathBuf>>>,
     theme: Theme,
 }
 
@@ -94,7 +94,7 @@ impl Application for Fuzzr {
                 toolbar: Toolbar::new(),
                 background_color: Color::new(1.0, 1.0, 1.0, 1.0),
                 ipfs_client: None,
-                publish_thumbs_paths: Arc::new(Mutex::new(Vec::new())),
+                publish_thumbs_paths: Arc::new(RwLock::new(Vec::new())),
                 theme: Theme::default(),
             },
             Command::perform(IpfsClient::new(), Message::IpfsReady),
@@ -126,7 +126,7 @@ impl Application for Fuzzr {
                 }
                 Message::IpfsReady(ipfs_client) => {
                     if let Ok(client) = ipfs_client {
-                        self.ipfs_client = Some(Arc::new(Mutex::new(client)))
+                        self.ipfs_client = Some(Arc::new(RwLock::new(client)))
                     };
                     Command::none()
                 }

--- a/src/data/ipfs_client.rs
+++ b/src/data/ipfs_client.rs
@@ -8,12 +8,12 @@ use libipld::cbor::DagCborCodec;
 use libipld::multihash::Code;
 use libipld::{Cid, IpldCodec};
 
-use async_std::sync::{Arc, Mutex};
+use async_std::sync::{Arc, RwLock};
 use directories_next::ProjectDirs;
 
 use crate::data::content::ContentItemBlock;
 
-pub type IpfsClientRef = Arc<Mutex<IpfsClient>>;
+pub type IpfsClientRef = Arc<RwLock<IpfsClient>>;
 
 #[derive(Clone, Debug, Default)]
 struct MaxBlockSizeStoreParams;

--- a/src/data/ipfs_ops.rs
+++ b/src/data/ipfs_ops.rs
@@ -40,7 +40,7 @@ pub async fn store_file(
             size_bytes,
         };
 
-        let ipfs_client = &ipfs_client.lock().await;
+        let ipfs_client = &ipfs_client.write().await;
         let cid = ipfs_client.add(&block).await?;
 
         info!(
@@ -58,7 +58,7 @@ pub async fn store_file(
                     size_bytes,
                 };
 
-                let ipfs_client = &ipfs_client.lock().await;
+                let ipfs_client = &ipfs_client.write().await;
                 let cid = ipfs_client.add(&block).await?;
 
                 info!(
@@ -86,7 +86,7 @@ pub async fn load_file(
 ) -> Result<ContentItem, Arc<Error>> {
     let start = Instant::now();
 
-    let ipfs_client = &ipfs_client.lock().await;
+    let ipfs_client = &ipfs_client.read().await;
     let cid = Cid::from_str(&cid_string).unwrap();
     let data = ipfs_client.get(&cid).await?;
 
@@ -104,7 +104,7 @@ mod tests {
     use super::*;
     use crate::data::ipfs_client::IpfsClient;
 
-    use async_std::{sync::Mutex, task::block_on};
+    use async_std::{sync::RwLock, task::block_on};
     use tempfile::tempdir;
 
     use std::{error::Error, fs::File};
@@ -123,7 +123,7 @@ mod tests {
 
     fn new_client() -> Result<IpfsClientRef, Box<dyn Error>> {
         block_on(async {
-            Ok(Arc::new(Mutex::new(
+            Ok(Arc::new(RwLock::new(
                 IpfsClient::new()
                     .await
                     .map_err(|e| Arc::try_unwrap(e).unwrap())?,

--- a/src/page/publish.rs
+++ b/src/page/publish.rs
@@ -5,7 +5,7 @@ use iced::{
 use log::{debug, error, info};
 use std::collections::BTreeMap;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use crate::data::content::PathThumb;
@@ -18,7 +18,7 @@ use crate::ui::style::Theme;
 pub struct PublishPage {
     // cid: Option<String>,
     scroll: scrollable::State,
-    publish_thumbs: Arc<Mutex<BTreeMap<PathBuf, PathThumb>>>,
+    publish_thumbs: Arc<RwLock<BTreeMap<PathBuf, PathThumb>>>,
     window_width: u16,
 }
 
@@ -29,12 +29,12 @@ impl Default for PublishPage {
 }
 
 async fn lock_insert(
-    publish_thumbs: Arc<Mutex<BTreeMap<PathBuf, PathThumb>>>,
+    publish_thumbs: Arc<RwLock<BTreeMap<PathBuf, PathThumb>>>,
     thumb: PathThumb,
     elapsed: Duration,
     remaining: isize,
 ) {
-    let mut publish_thumbs = publish_thumbs.lock().unwrap();
+    let mut publish_thumbs = publish_thumbs.write().unwrap();
     debug!(
         "Path:{:?}\nImage metadata: {:?}",
         &thumb.path, &thumb.metadata
@@ -52,7 +52,7 @@ impl PublishPage {
     pub fn new() -> PublishPage {
         PublishPage {
             scroll: scrollable::State::new(),
-            publish_thumbs: Arc::new(Mutex::new(BTreeMap::new())),
+            publish_thumbs: Arc::new(RwLock::new(BTreeMap::new())),
             window_width: 800,
         }
     }
@@ -95,7 +95,7 @@ impl PublishPage {
     }
 
     pub fn view(&mut self, theme: &Theme) -> Element<Message> {
-        let publish_thumbs = self.publish_thumbs.lock().unwrap();
+        let publish_thumbs = self.publish_thumbs.read().unwrap();
 
         if publish_thumbs.len() != 0 {
             // Thumbnail column distribution algorithm


### PR DESCRIPTION
RwLocks are similar to Mutexes, but it allows the program to have better information as to when the data should be locked. I wonder if there are even better data structures that allow for better data parallelism than a RwLock + BTreeMap to use for thumbnails when it comes to parallel processing, but this is a good start. Seems to shave off about 0.1-0.2s when processing around a thousand thumbnails with my test data set.